### PR TITLE
Fix version conflicts caused by PR#89

### DIFF
--- a/WhatIsHeDoing.DomainModels.APITest/WhatIsHeDoing.DomainModels.APITest.csproj
+++ b/WhatIsHeDoing.DomainModels.APITest/WhatIsHeDoing.DomainModels.APITest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup>
@@ -18,10 +18,10 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
-        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
+        <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
         <PackageReference Include="RoslynSecurityGuard" Version="2.3.0" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/WhatIsHeDoing.DomainModels.Tests/WhatIsHeDoing.DomainModels.Tests.csproj
+++ b/WhatIsHeDoing.DomainModels.Tests/WhatIsHeDoing.DomainModels.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/WhatIsHeDoing.DomainModels/WhatIsHeDoing.DomainModels.csproj
+++ b/WhatIsHeDoing.DomainModels/WhatIsHeDoing.DomainModels.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>net5.0</TargetFrameworks>
         <PackageId>WhatIsHeDoing.DomainModels </PackageId>
         <PackageVersion>4.1.0</PackageVersion>
         <Authors>WhatIsHeDoing</Authors>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.VisualStudio.Web.CodeGeneration.Design from 2.2.3 to 5.0.2. [(PR#89)](https://github.com/WhatIsHeDoing/WhatIsHeDoing.DomainModels/pull/89).
Hope this fix can help you.

Best regards,
sucrose